### PR TITLE
remove duplicate in content type from bogus raw emails

### DIFF
--- a/email/constructor_test.go
+++ b/email/constructor_test.go
@@ -545,3 +545,12 @@ func bytesOrPanic(b []byte, err error) []byte {
 	}
 	return b
 }
+
+func Test_RemoveMimeDuplicate(t *testing.T) {
+	contentType := "image/png; x-unix-mode=0644; name=image001.png; name=image001.png"
+
+	contentType = removeDuplicate(contentType)
+	if contentType != "image/png; x-unix-mode=0644; name=image001.png;" {
+		t.Fatal("Remove duplicate return an invalid value", contentType)
+	}
+}


### PR DESCRIPTION
I got and error when a content type contained a duplicate example:

`"image/png; x-unix-mode=0644; name=image001.png; name=image001.png"`

Go's `mime.ParseMediaType` returns an error if a duplicate like this is found causing the email parsing to stop, but this is only a bogus glitches that I think only some mail client would introduce.

I've added a `removeDuplicate` function that is call when the error: `mime: duplicate parameter name` is returned by `mime.ParseMediaType`.

It's basically simply removing duplicate and retry the function.