### PR TITLE
Fix "mail: no address" on send due to non-empty address slice.

### DIFF
--- a/email/header.go
+++ b/email/header.go
@@ -188,7 +188,11 @@ func (h Header) SetFrom(email string) {
 
 // To ...
 func (h Header) To() []string {
-	return strings.Split(h.Get("To"), ", ")
+	to := h.Get("To")
+	if to == "" {
+		return []string{}
+	}
+	return strings.Split(to, ", ")
 }
 
 // SetTo ...
@@ -198,7 +202,11 @@ func (h Header) SetTo(emails ...string) {
 
 // Cc ...
 func (h Header) Cc() []string {
-	return strings.Split(h.Get("Cc"), ", ")
+	cc := h.Get("Cc")
+	if cc == "" {
+		return []string{}
+	}
+	return strings.Split(cc, ", ")
 }
 
 // SetCc ...
@@ -208,7 +216,11 @@ func (h Header) SetCc(emails ...string) {
 
 // Bcc ...
 func (h Header) Bcc() []string {
-	return strings.Split(h.Get("Bcc"), ", ")
+	bcc := h.Get("Bcc")
+	if bcc == "" {
+		return []string{}
+	}
+	return strings.Split(bcc, ", ")
 }
 
 // SetBcc ...


### PR DESCRIPTION
Since the bcc, cc, to are string maps, it will default the get to a string slice of 1 item of empty string. This will fail the parse address on the send route.

	to := m.Header.To()
	cc := m.Header.Cc()
	bcc := m.Header.Bcc()
	all := make([]string, 0, len(to)+len(cc)+len(bcc))

Regardless of empty cc, bcc, or to, this all will default to a minimum of 3 items.

this will cause "address, err := mail.ParseAddress(all[i])" to return an err as all[i] will be of empty string.